### PR TITLE
Couple submodule updates and doc building

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,4 +1,10 @@
-on: [push]
+on:
+  push:
+  workflow_run:
+    workflows: [Update git submodules]
+    types:
+      - completed
+
 name: Build documentation
 
 jobs:


### PR DESCRIPTION
At the moment, the submodules are being updated in a manually triggered workflow while the documentation is built in a separate workflow. These two workflows need to be coupled so that updating the submodules also builds the documentation.

This is just an attempt at a solution. I am merging it, though, as the workflow needs to be merged to run because it is global to the repo.