### PR TITLE
Update docs URL in the README given new repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NanoVer Documentation
 
-Sphinx documentation for NanoVer, see the [documentation here](https://irl2.github.io/nanover/#).
+Sphinx documentation for NanoVer, see the [documentation here](https://irl2.github.io/nanover-docs/#).
 
 ## Getting Started
 


### PR DESCRIPTION
Updated the docs URL in the README to the new URL. The URL changed because the repo was changed from `nanover` to `nanover-docs`.