### PR TITLE
Fix modules link in tutorials page

### DIFF
--- a/source/modules.rst
+++ b/source/modules.rst
@@ -1,3 +1,5 @@
+.. _modules:
+
 Modules
 =======
 

--- a/source/tutorials/tutorials.rst
+++ b/source/tutorials/tutorials.rst
@@ -34,4 +34,4 @@ If you wish to access the Jupyter notebooks via `JupyterLab <https://jupyter.org
 Further reading
 ---------------
 
-For more details, look at the documentation for the individual :mod:`modules <modules>`.
+For more details, look at the documentation for the individual :ref:`modules <modules>`.


### PR DESCRIPTION
Currently the reference to the modules page at the bottom of the tutorials landing page doesn't link correctly to the modules page. This PR fixes this.