### PR TITLE
Update OpenMM tutorials page

### DIFF
--- a/source/tutorials/openmm.rst
+++ b/source/tutorials/openmm.rst
@@ -12,7 +12,7 @@ folder of the GitHub repository. It contains:
 
 * `openmm_polyalanine`: A notebook that demonstrates how to set up an interactive
   OpenMM simulation from scratch with NanoVer, use features of OpenMM in conjunction
-  with NanoVer, and how to record and playback simulations directly using NanoVer.
+  with NanoVer, and record & playback simulations directly using NanoVer.
 * `openmm_nanotube`: A notebook that demonstrates how to interact with an OpenMM
   NanoVer simulation using a python client.
 * `openmm_neuraminidase`: A notebook that demonstrates how to set up an interactive

--- a/source/tutorials/openmm.rst
+++ b/source/tutorials/openmm.rst
@@ -5,11 +5,16 @@ OpenMM
 A set of tutorials that demonstrate how to use NanoVer to run interactive molecular
 dynamics simulations using OpenMM directly.
 
-The Jupyter notebook tutorial that demonstrates how to run interactive molecular
+The Jupyter notebook tutorials that demonstrate how to run interactive molecular
 dynamics simulations by interfacing NanoVer with OpenMM directly can be found in
 the `examples <https://github.com/IRL2/nanover-protocol/tree/main/examples/openmm>`_
 folder of the GitHub repository. It contains:
 
-* `OpenMM runner`: A notebook that demonstrates how to set up interactive molecular
-  dynamics simulations within NanoVer using OpenMM directly, including creation of
-  input files, running the simulation and saving the generated trajectories.
+* `openmm_polyalanine`: A notebook that demonstrates how to set up an interactive
+  OpenMM simulation from scratch with NanoVer, use features of OpenMM in conjunction
+  with NanoVer, and how to record and playback simulations directly using NanoVer.
+* `openmm_nanotube`: A notebook that demonstrates how to interact with an OpenMM
+  NanoVer simulation using a python client.
+* `openmm_neuraminidase`: A notebook that demonstrates how to set up an interactive
+  OpenMM simulation from scratch with NanoVer and change the visualisations of
+  different atom selections for a protein-ligand system.


### PR DESCRIPTION
This PR updates the tutorials page to reflect the renaming and addition of tutorial notebooks to the OpenMM examples folder