### PR TITLE
Make code blocks copyable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 sphinx_rtd_theme
+sphinx-copybutton

--- a/source/conf.py
+++ b/source/conf.py
@@ -46,7 +46,7 @@ release = get_latest_release_version('IRL2', 'nanover-imd')
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.coverage', 'sphinx.ext.autosummary']
+              'sphinx.ext.coverage', 'sphinx.ext.autosummary', 'sphinx_copybutton']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -51,9 +51,17 @@ Installing the server
 
 If you have not already set up a NanoVer conda environment, please refer to :ref:`creating_conda_env`.
 
-#. Activate your NanoVer conda environment: ``conda activate nanover``
+#. Activate your NanoVer conda environment:
 
-#. Install the NanoVer packages: ``conda install -c irl -c conda-forge nanover-server``
+   .. code:: bash
+
+        conda activate nanover
+
+#. Install the NanoVer packages:
+
+   .. code:: bash
+
+        conda install -c irl -c conda-forge nanover-server
 
 For information on how to run NanoVer servers, check out the :ref:`tutorials <Tutorials>`.
 
@@ -149,11 +157,23 @@ Conda installation
 
 If you have not already set up a NanoVer conda environment, please refer to :ref:`creating_conda_env`.
 
-#. Activate your NanoVer conda environment: ``conda activate nanover``
+#. Activate your NanoVer conda environment:
 
-#. Install the NanoVer iMD package: ``conda install -c irl nanover-imd``
+   .. code:: bash
 
-#. To start the program, run the command ``NanoverImd``
+        conda activate nanover
+
+#. Install the NanoVer iMD package:
+
+   .. code:: bash
+
+        conda install -c irl nanover-imd
+
+#. To start the program, run the command:
+
+   .. code:: bash
+
+        NanoveriMD
 
 ----
 


### PR DESCRIPTION
Added the sphinx-copybutton package to the repo, making the code blocks copyable. Turned the in-line code in the Installation & Getting Started package to code blocks where needed.