### PR TITLE
Update the ASE tutorials page

### DIFF
--- a/source/tutorials/ase.rst
+++ b/source/tutorials/ase.rst
@@ -2,57 +2,19 @@
 ASE: Interactive Molecular Dynamics
 ===================================
 
-Running an ASE OpenMM server from the command line
-==================================================
+A set of tutorials that demonstrate how to use NanoVer to run interactive molecular
+dynamics simulations using ASE.
 
-When `nanover-ase` is installed, it provides the `nanover-omm-ase`
-command in the command line. When provided with the description of an
-OpenMM simulation as an XML file serialised as described in the `NanoVer OpenMM documentation <https://github.com/IRL2/nanover-protocol/tree/main/python-libraries/nanover-openmm>`_ 
-, `nanover-omm-ase` runs an interactive simulation. 
-The host address and port can be set with
-the ``--address`` and the ``--port`` option, respectively.
+The Jupyter notebook tutorials that demonstrate how to run interactive molecular dynamics simulations
+by interfacing NanoVer with ASE can be found in the
+`examples <https://github.com/IRL2/nanover-protocol/tree/main/examples/ase>`_ folder fo the GitHub
+repository. This folder also contains notebooks that explore how ASE can be used in NanoVer in
+conjunction with OpenMM. It contains:
 
-
-Running a server from python
-==================================================
-
-The `nanover-ase` module provides the
-:class:`nanover.ase.ASEImdServer` class. Given an ASE simulation set up with an 
-`ASE molecular dynamics runner <https://wiki.fysik.dtu.dk/ase/ase/md.html>`_, this class will 
-attach interactive molecular dynamics functionality and frame serving to the dynamics. 
-An example is given below, assuming an ASE Atoms object has been set up, named `atoms`:
-
-.. code-block:: python
-
-    from ase import units
-    from ase.md import Langevin
-    from nanover.ase.imd_server import ASEImdServer
-
-    # Given some ASE atoms object appropriately set up, set up dynamics.
-    dyn = Langevin(atoms, 1 * units.fs, 300, 0.1)
-
-    # Attach the IMD calculator and server to the dynamics object. 
-    imd = ASEImdServer(dyn)
-    while True:
-        imd.run(100)
-
-
-Full examples are given in the `examples <https://github.com/IRL2/nanover-protocol/tree/main/examples/ase>`_ folder, which additionally
-contains several Jupyter notebooks that explore how NanoVer can be used with OpenMM:
-
-* `basic_example`: A notebook showing how one can run the server for an OpenMM simulation,  connect a client to it, and render a simple visualisation. 
-* `openmm_nanotube`: A notebook that runs a simulation of a carbon nanotube, then applies interactive forces to it from the notebook.
-* `openmm_graphene`: A notebook that runs a simulation of a graphene sheet, and demonstrates how parameters of the simulation can be controlled in real
+* `ase_basic_example`: A notebook showing how one can run the server for an ASE simulation,  connect a client to it, and render a simple visualisation.
+* `ase_openmm_nanotube`: A notebook that runs a simulation of a carbon nanotube using ASE and OpenMM, then applies interactive forces to it from the notebook.
+* `ase_openmm_graphene`: A notebook that runs a simulation of a graphene sheet using ASE and OpenMM, and demonstrates how parameters of the simulation can be controlled in real
   time through the Jupyter notebook interface.
-* `openmm_neuraminidase`: A notebook that demonstrates how to construct an input file for an OpenMM simulation of neuraminidase to run with NanoVer from scratch.
-
-.. code-block:: bash
-
-    conda install nglview -c conda-forge
-    # might need: jupyter-nbextension enable nglview --py --sys-prefix
-
-    # if you already installed nglview, you can `upgrade`
-    conda upgrade nglview --force
-    # might need: jupyter-nbextension enable nglview --py --sys-prefix
-
+* `ase_openmm_neuraminidase`: A notebook that demonstrates how to construct an input file for an OpenMM simulation of neuraminidase to run with NanoVer from scratch, and then
+  runs the simulation using ASE with an OpenMM calculator.
 


### PR DESCRIPTION
This PR aims to update the ASE tutorials page by:

- Renaming the tutorial notebooks and updating their descriptions to reflect changes to these notebooks in nanover-protocol (see IRL2/nanover-protocol#274)
- Removes outdated code block example for ASE in python
- Removes outdated NGLView code block
- Rewrites text describing the tutorials

This is quite a significant change from the previous form of the page, and strips back a load of stuff that was outdated/inaccurate/unnecessary. Comments/suggestions welcome!