### PR TITLE
Add to the concepts pages (excluding `Recording data` and `Applications`)

### DIFF
--- a/source/concepts/applications.rst
+++ b/source/concepts/applications.rst
@@ -1,3 +1,5 @@
+.. _applications:
+
 Applications
 ============
 

--- a/source/concepts/architecture.rst
+++ b/source/concepts/architecture.rst
@@ -39,9 +39,9 @@ This architecture makes NanoVer very flexible.
 New features can be added as new services as needed, without cluttering up the main framework.
 We provide a number of service definitions and implementations, including:
 
-* :doc:`nanover.trajectory <../../python/nanover.trajectory>`: Provides trajectories and live simulations. 
-* :doc:`nanover.imd <../../python/nanover.imd>`: Provides methods for applying interactive biasing potentials to a simulation.
+* :doc:`nanover.trajectory <../../python/nanover.trajectory>`: Provides trajectories and live simulations.
 * :doc:`nanover.state <../../python/nanover.state>`: Provides synchronisation of avatars and state for multiplayer applications.
+* :doc:`nanover.command <../../python/nanover.command>`: Provides facilities to run arbitrary functions performed by the server.
 
 The services described above provide the core for the NanoVer iMD application, but the tools
 can be used to create custom services for different applications.
@@ -64,7 +64,8 @@ connect to a live simulation that can be visualised and interacted with through 
 
 Conceptually, the IMD server consists of three services: a trajectory service, a state service, and a command service.
 
-* **The trajectory service** publishes the changes in the simulation to clients, enabling it to be visualised.
+* **The trajectory service** provides updates as the state of the simulation progresses, enabling real-time analysis and
+  visualisation of the system.
 * **The state service**, meanwhile, takes care of incoming requests from the client applications to apply biasing potentials
   to the simulation. These are applied as forces to the molecular dynamics engine, which in turn integrates them.
   This service allows synchronisation of the state between all the clients and the server
@@ -79,10 +80,11 @@ A server application can leverage these three services to implement IMD to facil
 interaction with, a simulation in real time.
 
 
-Front End Architecture
-######################
+VR Front End
+############
 
-As the server side is modular, so too is the front end. The VR front end app,
-`NanoVer iMD <https://github.com/IRL2/nanover-imd>`_,
-is built using the `NanoVer Unity plugin <https://github.com/IRL2/NanoverUnityPlugin>`_,
-which provides a set of modules for building NanoVer applications.
+The VR front end app, :ref:`NanoVer iMD <vr-client-tutorial>`, intended for 3D visualisation and
+intuitive spatial iMD (iMD-VR), is a `distinct Unity/C# codebase <https://github.com/IRL2/nanover-imd>`_
+that follows the `gRPC protocol definitions <https://github.com/IRL2/nanover-protocol/tree/main/protocol/nanover/protocol>`_
+and :ref:`application conventions <applications>` laid out in the present documentation.
+

--- a/source/concepts/base-protocol.rst
+++ b/source/concepts/base-protocol.rst
@@ -41,7 +41,7 @@ The state service
 
 The **state service** maintains a state that is shared between the server
 and the clients. This section explores the technical details of the state
-service. For an interactive tutorial Jupyter notebook that
+service. For an interactive Jupyter notebook tutorial that
 complements the information presented in this section, check out our
 `commands_and_state` notebook (see :ref:`nanover-fundamentals`).
 
@@ -301,6 +301,9 @@ A ``FrameData`` contains two fields: ``values`` and ``arrays``.
 
 The meaning of the keys in both fields of the ``FrameData`` depends on the application.
 
+To see examples of how these types of data are added to frames in practice, take a look
+at our `frame` tutorial notebook (see :ref:`nanover-fundamentals`).
+
 .. code:: protobuf
 
     message FloatArray {
@@ -468,7 +471,7 @@ A server can expose functions that clients can call. Such functions can take
 arguments and return values. Each function itself should return shortly after
 being called.
 
-These functions are exposed through the command service. A client can use this
+These functions are exposed through the **command service**. A client can use this
 service to list the commands that are available and to call commands.
 
 Each command has a name and a list of arguments. The name is an arbitrary
@@ -543,3 +546,7 @@ code.
    The protocol does not have an in-built way of handling errors during the
    execution of the command. It does not have an in-built way of handling
    long-running commands either.
+
+For an interactive Jupyter notebook tutorial that demonstrates how to set up
+and run commands in practice, check out our `commands_and_state` notebook
+(see :ref:`nanover-fundamentals`).

--- a/source/concepts/base-protocol.rst
+++ b/source/concepts/base-protocol.rst
@@ -15,8 +15,8 @@ NanoVer provides three services: the **state service**, the **trajectory service
 and the **command service**. While none of these services are strictly
 mandatory, some features expect two or three services to cooperate.
 
-The **state service** maintains a state that is shared between the server
-and one or more clients. The state is presented as a key-value store;
+The **state service** coordinates a shared data store that is shared between
+the server and one or more clients. The state is presented as a key-value store;
 users can subscribe to updates to the state, send updates themselves,
 and request exclusive write access to some keys. This service is used to:
 share the position of the users' avatars, send users' interactions
@@ -39,9 +39,9 @@ address and port. The default port is 38801.
 The state service
 -----------------
 
-The **state service** maintains a state that is shared between the server
-and the clients. This section explores the technical details of the state
-service. For an interactive Jupyter notebook tutorial that
+The **state service** coordinates a shared data store that is shared between
+the server and the clients. This section explores the technical details of
+the state service. For an interactive Jupyter notebook tutorial that
 complements the information presented in this section, check out our
 `commands_and_state` notebook (see :ref:`nanover-fundamentals`).
 

--- a/source/concepts/base-protocol.rst
+++ b/source/concepts/base-protocol.rst
@@ -245,10 +245,10 @@ should be considered publicly exposed.
 The trajectory service
 ----------------------
 
-A server can broadcast molecular systems using the trajectory service.
+A server can broadcast molecular systems using the **trajectory service**.
 Molecular systems can be running simulations, static structures, recorded
 trajectories, or any collection of particles regardless of how they are
-produced. They are represented as a sequence of one or more frames where each
+produced. They are represented as a sequence of one or more **frames** where each
 frame represents a state of the molecular system.
 
 .. note::
@@ -265,7 +265,12 @@ Frame description
 
 .. code:: protobuf
 
-    /* A general structure to represent a frame of a trajectory. It is similar in structure to the Google Struct message, representing dynamically typed objects and lists. However, as frames often consist of large arrays of data of the same type, a set of arrays are also provided as specified in nanover/protocol/array.proto */
+    /* A general structure to represent a frame of a trajectory.
+    It is similar in structure to the Google Struct message,
+    representing dynamically typed objects and lists. However,
+    as frames often consist of large arrays of data of the same
+    type, a set of arrays are also provided as specified in
+    nanover/protocol/array.proto */
     message FrameData {
 
       /* A standard key-value list of dynamically typed data */
@@ -281,19 +286,20 @@ the trajectory. An implementation using this structure needs to maintain an
 aggregate ``FrameData`` and merge all incoming frames to get the current state
 of the system.
 
-A ``FrameData`` contains two fields: ``values`` and ``arrays``. The ``values``
-field is a key-value map with string keys and protobuf `Value
-<https://protobuf.dev/reference/protobuf/google.protobuf/#value>`_ as values.
-This map aims at storing simple data related to the frame: data consisting of a
-single number, boolean, or string. This being said, it can contain more complex data structures
-such as heterogeneous lists or protobuf `Struct
-<https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Struct>`_.
-Homogeneous arrays (i.e. arrays where all the values have the same type) can
-be stored in the ``arrays`` field of the ``FrameData`` where keys are strings
-and values are ``ValueArray`` as described below. A ``ValueArray`` can contain
-a homogeneous array of either floats (``FloatArray``), unsigned integers
-(``IndexArray``), or strings (``StringArray``). The meaning of the keys in both
-fields of the ``FrameData`` depends on the application.
+A ``FrameData`` contains two fields: ``values`` and ``arrays``.
+
+* The ``values`` field is a key-value map where each key is a string and each value is
+  a protobuf `Value <https://protobuf.dev/reference/protobuf/google.protobuf/#value>`_.
+  This map typically stores simple data related to the frame: data consisting of a
+  single number, boolean, or string. This being said, it can contain more complex data structures
+  such as heterogeneous lists or protobuf `Structs
+  <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Struct>`_.
+* The ``arrays`` field is a key-value map in which homogeneous arrays (i.e. arrays
+  where all the values have the same type) can be stored. In this map, each key is a string
+  and each value is a ``ValueArray``, which can contain a homogeneous array of either
+  floats (``FloatArray``), unsigned integers (``IndexArray``), or strings (``StringArray``).
+
+The meaning of the keys in both fields of the ``FrameData`` depends on the application.
 
 .. code:: protobuf
 
@@ -380,17 +386,22 @@ Subscribing to the latest frames
 
 .. code:: protobuf
 
-    /* A service which provides access to frames of a trajectory, which may either be precomputed or represent a live simulation. It can also be used to obtain one or more frames on demand, allowing molecules or trajectories to be generated based on requests */
+    /* A service which provides access to frames of a trajectory,
+    which may either be precomputed or represent a live simulation.
+    It can also be used to obtain one or more frames on demand,
+    allowing molecules or trajectories to be generated based on requests */
     service TrajectoryService {
 
-      /* Subscribe to a continuous updating source of frames. The client gets the latest available frame at the time of transmission. */
+      /* Subscribe to a continuous updating source of frames.
+      The client gets the latest available frame at the time of transmission. */
       rpc SubscribeLatestFrames (GetFrameRequest) returns (stream GetFrameResponse);
     }
 
     /* A client request to get frame(s) from a trajectory service */
     message GetFrameRequest {
 
-      /* Arbitrary data that can be used by a TrajectoryService to decide what frames to return */
+      /* Arbitrary data that can be used by a TrajectoryService to
+      decide what frames to return */
       google.protobuf.Struct data = 1;
 
       /* Interval to send new frames at e.g 1/30 sends 30 frames every second. */
@@ -423,10 +434,14 @@ Subscribing to all frames
 
 .. code:: protobuf
 
-    /* A service which provides access to frames of a trajectory, which may either be precomputed or represent a live simulation. It can also be used to obtain one or more frames on demand, allowing molecules or trajectories to be generated based on requests */
+    /* A service which provides access to frames of a trajectory,
+    which may either be precomputed or represent a live simulation.
+    It can also be used to obtain one or more frames on demand,
+    allowing molecules or trajectories to be generated based on requests */
     service TrajectoryService {
 
-      /* Subscribe to a continuous updating source of frames. Frames are added to the stream when they are available */
+      /* Subscribe to a continuous updating source of frames.
+      Frames are added to the stream when they are available */
       rpc SubscribeFrames (GetFrameRequest) returns (stream GetFrameResponse);
     }
 

--- a/source/concepts/base-protocol.rst
+++ b/source/concepts/base-protocol.rst
@@ -11,11 +11,11 @@ The NanoVer protocol
 General architecture
 --------------------
 
-NanoVer provides three services: the state service, the trajectory service,
-and the command service. While none of these services are strictly
+NanoVer provides three services: the **state service**, the **trajectory service**,
+and the **command service**. While none of these services are strictly
 mandatory, some features expect two or three services to cooperate.
 
-The *state service* maintains a state that is shared between the server
+The **state service** maintains a state that is shared between the server
 and one or more clients. The state is presented as a key-value store;
 users can subscribe to updates to the state, send updates themselves,
 and request exclusive write access to some keys. This service is used to:
@@ -23,11 +23,11 @@ share the position of the users' avatars, send users' interactions
 with molecular systems, and share the molecular representations. It
 can be used to send any arbitrary data to the server and to the clients.
 
-The *trajectory service* allows the server to broadcast the state of a
+The **trajectory service** allows the server to broadcast the state of a
 simulation to the clients. It sends frames to the clients at the
 requested frame rate.
 
-The *command service* lets client run functions on the server. For example,
+The **command service** lets client run functions on the server. For example,
 this service is used to pause or reset a molecular simulation.
 
 The services can all be served from different addresses and/or a
@@ -39,8 +39,11 @@ address and port. The default port is 38801.
 The state service
 -----------------
 
-The state service maintains a state that is shared between the server
-and the clients.
+The **state service** maintains a state that is shared between the server
+and the clients. This section explores the technical details of the state
+service. For an interactive tutorial Jupyter notebook that
+complements the information presented in this section, check out our
+`commands_and_state` notebook (see :ref:`nanover-fundamentals`).
 
 .. _state-updates:
 
@@ -209,11 +212,15 @@ duration in seconds or a `Null value
 <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.NullValue>`_
 as value. If the value is a duration, then the lock is created or renewed with
 the requested validity duration. If the value is null, then the lock is deleted.
-A lock can only be updated if: it does not yet exist, or if it exists but has
-expired, or if it is held by the same access token as the request. Each update
-can be about one or multiple locks; a request only succeeds if all the locks can
-be updated. If any of the locks cannot be updated, then none of the locks are
-updated.
+A lock can only be updated if:
+
+* it does not yet exist
+* it exists but has expired
+* it is held by the same access token as the request
+
+Each update can be about one or multiple locks; a request only succeeds if
+all the locks can be updated. If any of the locks cannot be updated, then
+none of the locks are updated.
 
 .. note::
 

--- a/source/concepts/base-protocol.rst
+++ b/source/concepts/base-protocol.rst
@@ -321,8 +321,17 @@ needs to contain the full array in ``arrays`` even if only a
 single element of it has changed. When merging, key-value pairs from the new frame
 replace those from the aggregated frame. Key-value pairs that are only in the
 new frame are added to the aggregated frame. Pairs that do not appear in the
-new frame remain untouched in the aggregated one. Here is an example of frames
-being merged:
+new frame remain untouched in the aggregated one.
+
+.. note::
+
+   This aggregation process is made use of in NanoVer's interactive molecular
+   dynamics application, in which clients can access the most
+   recent updates to the frame (:py:attr:`NanoverImdClient.latest_frame`) or
+   the full set of aggregated data pertaining to the current frame of the
+   simulation (:py:attr:`NanoverImdClient.current_frame`).
+
+Here is an example of frames being merged:
 
 ::
 

--- a/source/concepts/frames.rst
+++ b/source/concepts/frames.rst
@@ -9,14 +9,19 @@ of these frames, forming a three dimensional 'movie'. Simulations are essentiall
 trajectories which are being generated on the fly.
 
 Each frame consists of information about the system and the atoms within it. This
-data takes the form of values related to the frame (such as the system's temperature
-or energy) and arrays storing information about the atoms themselves (such as position
-or element).
+data takes the form of **values** related to the frame (such as the system's instantaneous temperature
+or potential energy) and **arrays** storing information about the atoms themselves (such as position
+or element symbol). Some of these data are updated each frame as the simulation progresses (such
+as particle positions, simulation time or system potential energy) whilst others remain constant
+throughout the simulation (such as element type or number of particles). NanoVer handles this by
+only updating values or arrays that change between frames; to find out more about
+this, please refer to :ref:`frame-description`.
 
-The approach taken by NanoVer is to use a key value system to store frames, as what is 
+The approach taken by NanoVer is to use a key-value system to store frames, as what is
 available in a frame varies dramatically based on what is being simulated. NanoVer applications
 use a set of standard keys to define common fields, such as 'particle_positions' for the the field
-containing the coordinates of the particles in the system. See the python implementation of :py:class:`FrameData <nanover.trajectory.frame_data.FrameData>`
+containing the coordinates of the particles in the system. See the python implementation of
+:py:class:`FrameData <nanover.trajectory.frame_data.FrameData>`
 or some of our :py:mod:`conversion <nanover.openmm.converter>`  utilities for more examples.
 
 For a basic interactive molecular simulation, a frame typically has the following fields:
@@ -39,4 +44,8 @@ While in a QM calculation, we may have:
 
 If you need to customize a frame with your own data, you can - just pick a good key by which to identify
 it, and convert your data into either an array of integers, bytes, floats, strings, or a single value type such as 
-integer, byte, float, string, or a JSON like Struct. 
+integer, byte, float, string, or a JSON like `Struct
+<https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Struct>`_.
+
+To learn more about the types of data you can send in a frame, or to see how to add data to a frame in practice,
+take a look at our `frame` tutorial notebook (see :ref:`nanover-fundamentals`).

--- a/source/tutorials/fundamentals.rst
+++ b/source/tutorials/fundamentals.rst
@@ -1,3 +1,5 @@
+.. _nanover-fundamentals:
+
 ====================
 NanoVer Fundamentals
 ====================


### PR DESCRIPTION
This PR aims to add the final touches to three of the NanoVer Concepts pages:

- `NanoVer Architecture`
- `Trajectories and Frames`
- `The NanoVer Protocol`

Much of the information in these pages reflects how the core of NanoVer works (i.e. the protocol itself) which (to my knowledge) hasn't changed and is therefore correct. This PR adds some minor additions, rewordings, restructurings and links to the complementary tutorial notebooks that present the same concepts (where appropriate).