### PR TITLE
Make contents 'local' on Installation page

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -10,7 +10,8 @@ and applications for visualising & interacting with simulations
 in VR.
 
 .. contents:: Contents
-    :depth: 3
+    :depth: 2
+    :local:
 
 ----
 


### PR DESCRIPTION
Previously, the list of contents at the top of the Installation page included the title of the page. I have changed this to a 'local' contents, which stops this happening and is consistent with the formatting of the rest of the docs.