### PR TITLE
adding description of `multiple_simulations` notebook in the docs

### DIFF
--- a/source/tutorials/basics.rst
+++ b/source/tutorials/basics.rst
@@ -28,10 +28,11 @@ of the GitHub repository:
   pre-prepared methane & nanotube system.
 * `recording_and_replaying`: An introductory notebook that demonstrates how NanoVer can be used
   to record and replay iMD simulations.
+* `multiple_simulations`: This notebook demonstrates how to load and run multiple simulation files using a single OmniRunner server,
+  providing default visualizations, and details how to switch between them using the Jupyter notebook and VR interfaces.
 * `nanover_nglview`: A notebook that assumes a server is already running, and visualises it
   with `NGLView <https://github.com/arose/nglview>`_.
-* `multiple_simulations`: This notebook demonstrates how to load and run multiple simulation files into
-  a single OmniRunner server, providing default visualizations, and switch among them within a single VR session.
+
 
 
 .. _basicsrunningaserver:

--- a/source/tutorials/basics.rst
+++ b/source/tutorials/basics.rst
@@ -34,7 +34,6 @@ of the GitHub repository:
   with `NGLView <https://github.com/arose/nglview>`_.
 
 
-
 .. _basicsrunningaserver:
 
 Running a server

--- a/source/tutorials/basics.rst
+++ b/source/tutorials/basics.rst
@@ -30,6 +30,8 @@ of the GitHub repository:
   to record and replay iMD simulations.
 * `nanover_nglview`: A notebook that assumes a server is already running, and visualises it
   with `NGLView <https://github.com/arose/nglview>`_.
+* `multiple_simulations`: This notebook demonstrates how to load and run multiple simulation files into
+  a single OmniRunner server, providing default visualizations, and switch among them within a single VR session.
 
 
 .. _basicsrunningaserver:


### PR DESCRIPTION
This pull request adds a single sentence description of the `multiple_simulations` jupyter notebook tutorial, in the corresponding NanoVer Basics tutorial page.