### PR TITLE
Add warning about broken renderers on apk build

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -189,6 +189,13 @@ Download the latest release
 
     \ **Tethered**: using a cable to connect your VR headset to your computer.
 
+.. warning::
+
+    Some renderers do not render correctly when using the standalone apk build, including ``cartoon``,
+    ``geometric spline``, and ``noodles``.
+    We are currently working to resolve this, please see the
+    `issue <https://github.com/IRL2/nanover-server-py/issues/192>`_ on our git repo for updates.
+
 ----
 
 

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -191,8 +191,8 @@ Download the latest release
 
 .. warning::
 
-    Some renderers do not render correctly when using the standalone apk build, including ``cartoon``,
-    ``geometric spline``, and ``noodles``.
+    Some renderers do not render correctly when using the standalone apk build, including ``spline``,
+    ``geometric spline``, and ``cartoon``.
     We are currently working to resolve this, please see the
     `issue <https://github.com/IRL2/nanover-server-py/issues/192>`_ on our git repo for updates.
 

--- a/source/tutorials/vrclient.rst
+++ b/source/tutorials/vrclient.rst
@@ -636,4 +636,11 @@ Please choose from the dropdown options below to learn about how to install Nano
 
     Choosing this option means that you cannot run NanoVer iMD-VR via conda.
 
+.. warning::
+
+    Some renderers do not render correctly when using the standalone apk build, including ``cartoon``,
+    ``geometric spline``, and ``noodles``.
+    We are currently working to resolve this, please see the
+    `issue <https://github.com/IRL2/nanover-server-py/issues/192>`_ on our git repo for updates.
+
 |


### PR DESCRIPTION
Added a warning on the installation page and the iMD-VR tutorial page to say that there are issues with rendering on the standalone apk build, with a link to the issue on the nanover-server-py repo.