### PR TITLE
Clarify that NanoVer iMD-VR conda installation is for windows only

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -95,12 +95,20 @@ Installing the iMD-VR client
 
 To use NanoVer iMD-VR, you have two options:
 
-* **Conda installation of the NanoVer iMD-VR package**. This is a good option if you are familiar with conda (or want to learn how to use it!), see :ref:`conda_installation_VR_client`.
+* **Conda installation of the NanoVer iMD-VR package**: :ref:`conda_installation_VR_client`.
+  *Please note that this installs the Windows build of the package, thus is not compatible with MacOS or Linux.*
 
-* **Download the latest release of the NanoVer iMD-VR executable**. This is a quick and easy option for those unfamiliar with conda, see :ref:`download_latest_release_VR_client`.
 
-For more information on how to choose your installation method based on your VR setup, please check out the
-:ref:`choosing your iMD-VR setup<choosing_setup_iMD-VR>` section on the NanoVer iMD-VR tutorial page.
+* **Download the latest release of the NanoVer iMD-VR executable**: :ref:`download_latest_release_VR_client`.
+  This directory includes: (a) the Windows build of the package, and (b) the standalone apk for installation on your
+  Meta Quest headset.
+  *If you are using MacOS or Linux, you must use the standalone apk.*
+
+.. admonition:: Important
+
+    For more information on how to choose your installation method based on your VR setup and operating system,
+    please check out the :ref:`choosing your iMD-VR setup<choosing_setup_iMD-VR>` section on the NanoVer iMD-VR
+    tutorial page.
 
 
 .. _conda_installation_VR_client:

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -95,14 +95,14 @@ Installing the iMD-VR client
 
 To use NanoVer iMD-VR, you have two options:
 
-* **Conda installation of the NanoVer iMD-VR package**: :ref:`conda_installation_VR_client`.
+* **Conda installation of the NanoVer iMD-VR package**, see :ref:`conda_installation_VR_client`.
   *Please note that this installs the Windows build of the package, thus is not compatible with MacOS or Linux.*
 
 
-* **Download the latest release of the NanoVer iMD-VR executable**: :ref:`download_latest_release_VR_client`.
+* **Download the latest release of the NanoVer iMD-VR executable**, see :ref:`download_latest_release_VR_client`.
   This directory includes: (a) the Windows build of the package, and (b) the standalone apk for installation on your
   Meta Quest headset.
-  *If you are using MacOS or Linux, you must use the standalone apk.*
+  *If you are using MacOS or Linux, you must run the program locally on your Meta Quest headset using the standalone apk.*
 
 .. admonition:: Important
 

--- a/source/tutorials/vrclient.rst
+++ b/source/tutorials/vrclient.rst
@@ -605,7 +605,7 @@ Choosing your installation method
 
 Please choose from the dropdown options below to learn about how to install NanoVer iMD-VR with your chosen VR setup:
 
-.. dropdown:: Using PC-VR
+.. dropdown:: Using PC-VR (Windows only)
 
     This option is compatible with the following VR setups:
 


### PR DESCRIPTION
Clarified that conda installation of `nanover-imd` is for Windows only, because it installs the windows build. Also clarified where necessary, that the only option for MacOS/Linux users is to use the standalone apk.