### PR TITLE
Edit landing page to reflect current NanoVer usage

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -3,22 +3,22 @@ Welcome to NanoVer's documentation!
 
 NanoVer is a free, open-source and flexible software that can be used as:
 
-(1) A **framework** for building **multi-user virtual reality applications** for molecular systems.
-(2) A **client-server** application for **collaborative interactive molecular dynamics simulations in virtual reality** (iMD-VR).
+(1) A **client-server** application for **collaborative interactive molecular dynamics simulations in virtual reality** (iMD-VR).
+(2) A **framework** for building **multi-user virtual reality applications** for molecular systems.
 
 NanoVer is distributed under the `MIT <https://github.com/IRL2/nanover-server-py/blob/main/LICENSE>`_ license.
 
 ----
 
-As a client-server application, NanoVer consists of:
+As a client-server application for **interactive molecular dynamics** (iMD), NanoVer consists of:
 
 (1) **The NanoVer server**: the server communicates with a physics engine, e.g. OpenMM, to facilitate
     interactive MD simulations.
 (2) **A NanoVer client**: a client that can connect to a NanoVer server to access simulation data and
-    facilitate user interaction with the molecular system. This can be done using:
+    facilitate user interaction with the molecular system. This can be achieved using:
 
     * A **python client**: a python script, e.g. a Jupyter notebook. Check out the :ref:`tutorials <Tutorials>` for further information.
-    * A **-VR client**: an instance of the NanoVer iMD-VR program
+    * A **VR client**: an instance of the NanoVer iMD-VR program
       (see the `latest releases here <https://github.com/IRL2/nanover-imd-vr/releases>`_) that enables a user to
       visualise and interact with the real-time MD simulation in VR.
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -6,7 +6,7 @@ NanoVer is a free, open-source and flexible software that can be used as:
 (1) A **framework** for building **multi-user virtual reality applications** for molecular systems.
 (2) A **client-server** application for **collaborative interactive molecular dynamics simulations in virtual reality** (iMD-VR).
 
-Nanover is distributed under the `MIT <https://github.com/IRL2/nanover-server-py/blob/main/LICENSE>`_ license.
+NanoVer is distributed under the `MIT <https://github.com/IRL2/nanover-server-py/blob/main/LICENSE>`_ license.
 
 ----
 
@@ -18,7 +18,7 @@ As a client-server application, NanoVer consists of:
     facilitate user interaction with the molecular system. This can be done using:
 
     * A **python client**: a python script, e.g. a Jupyter notebook. Check out the :ref:`tutorials <Tutorials>` for further information.
-    * A **-VR client**: an instance of the Nanover iMD-VR program
+    * A **-VR client**: an instance of the NanoVer iMD-VR program
       (see the `latest releases here <https://github.com/IRL2/nanover-imd-vr/releases>`_) that enables a user to
       visualise and interact with the real-time MD simulation in VR.
 


### PR DESCRIPTION
This PR edits the landing page for NanoVer. So far, I have:

- Swapped the definitions of what NanoVer is/how it can be used
- Fixed existing typos (i.e. `Nanover` -> `NanoVer`, removing hyphen before `VR client`)
- Added reference to iMD (without VR)
- Edited wording slightly

If anyone has any suggestions about further possible improvements, feel free to add comments!