### PR TITLE
Use latest submodule commit in build process

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -48,6 +48,8 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+      - name: Update submodules locally
+        run: git submodule update --remote
       - name: Check commit count for version
         run: |
           cd nanover-server-py

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ can be found [here](https://github.com/IRL2/nanover-server-py/blob/main/README.m
 Make sure the submodules are initialised: 
 
 ```
-git submodule update --init --recursive
+git submodule update --init --recursive --remote
 ```
 
 To build the docs, on Linux/ Mac OS X:


### PR DESCRIPTION
Makes the build action locally update submodules, so that it will always build docs with the latest main regardless of whether the submodule is behind in the repo or not.