### PR TITLE
Update links to "examples" directory

### DIFF
--- a/source/tutorials/ase.rst
+++ b/source/tutorials/ase.rst
@@ -7,7 +7,7 @@ dynamics simulations using ASE.
 
 The Jupyter notebook tutorials that demonstrate how to run interactive molecular dynamics simulations
 by interfacing NanoVer with ASE can be found in the
-`examples <https://github.com/IRL2/nanover-server-py/tree/main/examples/ase>`_ folder fo the GitHub
+`tutorials <https://github.com/IRL2/nanover-server-py/tree/main/tutorials/ase>`_ folder of the GitHub
 repository. This folder also contains notebooks that explore how ASE can be used in NanoVer in
 conjunction with OpenMM. It contains:
 

--- a/source/tutorials/basics.rst
+++ b/source/tutorials/basics.rst
@@ -23,7 +23,7 @@ exhibit some core features of NanoVer in a quick, intuitive way. If you are new 
 these tutorials are the perfect place to start!
 
 Here we give a summary of the available Jupyter notebook tutorials, that can be found in the
-`examples <https://github.com/IRL2/nanover-server-py/tree/main/examples/basics>`_ folder
+`tutorials <https://github.com/IRL2/nanover-server-py/tree/main/tutorials/basics>`_ folder
 of the GitHub repository:
 
 * `getting_started`: **New to NanoVer? Start here!** An introductory notebook that showcases how

--- a/source/tutorials/fundamentals.rst
+++ b/source/tutorials/fundamentals.rst
@@ -8,7 +8,7 @@ We provide a set of Jupyter notebook tutorials that introduce NanoVer as a frame
 molecular dynamics simulations, and the fundamental concepts associated with the client-server
 architecture that NanoVer uses. These tutorials can be used in conjunction with the
 information in :ref:`concepts <Concepts>` to understand how NanoVer works and are found in the
-`examples <https://github.com/IRL2/nanover-server-py/tree/main/examples/fundamentals>`_ folder of the GitHub repository.
+`tutorials <https://github.com/IRL2/nanover-server-py/tree/main/tutorials/fundamentals>`_ folder of the GitHub repository.
 
 Here we give a summary of each tutorial:
 

--- a/source/tutorials/mdanalysis.rst
+++ b/source/tutorials/mdanalysis.rst
@@ -6,7 +6,7 @@ A set of tutorials that demonstrate how NanoVer can be interfaced with MDAnalysi
 trajectories in VR, and analyse the results of trajectories recorded using NanoVer.
 
 The Jupyter notebook tutorials that showcase these features can be found in the
-`examples <https://github.com/IRL2/nanover-server-py/tree/main/examples/mdanalysis>`_ folder of the GitHub repository.
+`tutorials <https://github.com/IRL2/nanover-server-py/tree/main/tutorials/mdanalysis>`_ folder of the GitHub repository.
 It contains:
 
 * `mdanalysis_lsd`: A notebook that demonstrates how to import a pdb into MDAnalysis and visualise this structure in VR,

--- a/source/tutorials/openmm.rst
+++ b/source/tutorials/openmm.rst
@@ -17,7 +17,7 @@ dynamics simulations using OpenMM directly.
 
 The Jupyter notebook tutorials that demonstrate how to run interactive molecular
 dynamics simulations by interfacing NanoVer with OpenMM directly can be found in
-the `examples <https://github.com/IRL2/nanover-server-py/tree/main/examples/openmm>`_
+the `tutorials <https://github.com/IRL2/nanover-server-py/tree/main/tutorials/openmm>`_
 folder of the GitHub repository. It contains:
 
 * `openmm_polyalanine`: A notebook that demonstrates how to set up an interactive


### PR DESCRIPTION
The "examples" directory has now been renamed to "tutorials" in the nanover-server-py repo. This has been updated in all of the relevant tutorial pages.