### PR TITLE
Update warning in installation documentation for standalone apk build

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -202,8 +202,8 @@ Download the latest release
 
 .. warning::
 
-    Some renderers do not render correctly when using the standalone apk build, namely ``spline``and
-    ``geometric spline``.
+    Some renderers do not render correctly when using the standalone apk build, namely ``spline`` and
+    ``geometric spline`` .
     We are currently working to resolve this, please see the
     `issue <https://github.com/IRL2/nanover-imd-vr/issues/75>`_ on our git repo for updates.
 

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -202,10 +202,10 @@ Download the latest release
 
 .. warning::
 
-    Some renderers do not render correctly when using the standalone apk build, including ``spline``,
-    ``geometric spline``, and ``cartoon``.
+    Some renderers do not render correctly when using the standalone apk build, namely ``spline``and
+    ``geometric spline``.
     We are currently working to resolve this, please see the
-    `issue <https://github.com/IRL2/nanover-server-py/issues/192>`_ on our git repo for updates.
+    `issue <https://github.com/IRL2/nanover-imd-vr/issues/75>`_ on our git repo for updates.
 
 |
 


### PR DESCRIPTION
This pull request includes a small update to the `source/installation.rst` file. The change updates the list of renderers that do not render correctly when using the standalone apk build and provides a new link to the relevant issue on the GitHub repository.

* [`source/installation.rst`](diffhunk://#diff-4884762d45afdc700a95e9473a1a37dc0736217be75f8989187f742bc42d987aL205-R208): Updated the list of problematic renderers and changed the issue link to point to the correct repository.