### PR TITLE
Remove warning about broken renderers

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -200,15 +200,6 @@ Download the latest release
 
     \ **Tethered**: using a cable to connect your VR headset to your computer.
 
-.. warning::
-
-    Some renderers do not render correctly when using the standalone apk build, namely ``spline`` and
-    ``geometric spline`` .
-    We are currently working to resolve this, please see the
-    `issue <https://github.com/IRL2/nanover-imd-vr/issues/75>`_ on our git repo for updates.
-
-|
-
 ----
 
 


### PR DESCRIPTION
This rendering issue has been fixed with the recent updates to the NanoVer VR application, thus the warning is not applicable anymore.