### PR TITLE
Fix instructions for installing Nanover iMD-VR via Conda

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -130,7 +130,7 @@ If you have not already created a NanoVer conda environment, please refer to
 
    .. code:: bash
 
-        conda install -c irl nanover-imd
+        conda install -c irl nanover-imd-vr
 
 #. Set up your VR headset.
 
@@ -138,8 +138,9 @@ If you have not already created a NanoVer conda environment, please refer to
 
    .. code:: bash
 
-        NanoveriMD
+        nanover-imd-vr
 
+The page for the Conda package can be found here: `<https://anaconda.org/irl/nanover-imd-vr>`_.
 
 .. _download_latest_release_VR_client:
 


### PR DESCRIPTION
The imd-vr conda package has moved from https://anaconda.org/irl/narupa-imd to https://anaconda.org/irl/nanover-imd-vr.

This PR updates the associated change in the package name (`nanover-imd` to `nanover-imd-vr`), and the command for running imd-vr (`nanoverimd` to `nanover-imd-vr`). 