### PR TITLE
Remove references to rust server

### DIFF
--- a/source/concepts/applications.rst
+++ b/source/concepts/applications.rst
@@ -598,7 +598,6 @@ A trajectory application can define the following commands to control the stream
 * ``playback/next() -> None``: switches from the current system to the next
   system in the list of available systems, as listed by the ``playback/list`` command.
   When called from the final system, cycles back to the first system.
-  Note that the Rust server does not cycle back after the final system.
   This command does not take any arguments and does not return anything.
 
 .. warning::
@@ -838,10 +837,6 @@ Under that key, the value is a Struct with the following keys:
 * ``reset_velocities``: a boolean, true if :ref:`velocity reset
   <velocity-reset>` should be applied, false otherwise. This is false by
   default and will be ignored silently if the server does not have the feature.
-
-.. warning::
-
-   The Rust server does not currently support non-mass-weighted interactions.
 
 .. note::
 

--- a/source/tutorials/basics.rst
+++ b/source/tutorials/basics.rst
@@ -49,18 +49,6 @@ of the GitHub repository:
 Running a server
 ################
 
-Introduction
-############
-
-There are two NanoVer servers available:
-
-* **The NanoVer Python Server**, found in the `nanover-server-py <https://github.com/IRL2/nanover-server-py>`_ git repo.
-  This server is written in Python and is the go-to server for NanoVer users.
-* The NanoVer Rust Server, found in the `nanover-server-rs <https://github.com/IRL2/nanover-server-rs>`_ git repo, and is written
-  in Rust. We include brief instructions for using this server on this page, but we recommend using the Python Server.
-
-----
-
 The NanoVer Python server
 #########################
 
@@ -125,113 +113,6 @@ If everything is set up correctly, you should see the following interface:
 .. image:: /_static/GUI-py.png
     :align: center
     :scale: 50%
-
-|
-
-----
-
-The NanoVer Rust Server
-#######################
-
-The NanoVer Rust Server is compiled into an executable (or equivalent, depending on your operating system), rather than being
-installed on your computer. For this, you have two options:
-
-* Download the `latest release <https://github.com/IRL2/nanover-server-rs/releases>`_ from the git repo, ensuring you choose
-  the correct option for your operating system.
-* Compile it yourself using the source code by following the instructions in the
-  `README <https://github.com/IRL2/nanover-server-rs>`_.
-
-This program can run NanoVer OpenMM simulations and NanoVer recordings (but not simulations that use ASE as
-an interface) and has many features, including:
-
-* Recording NanoVer sessions
-* Loading multiple simulations and/or recordings onto a single server, and switching between them while the
-  server is running
-* A graphical user interface (GUI), useful for new users to familiarise themselves quickly and easily with the various
-  options offered by NanoVer
-
-To **run the server**, first, navigate to the build directory:
-
-* If you have downloaded the latest release, extract the files from the zip folder and navigate to the build directory:
-  this directory will be named ``{operating_sys}-build`` (e.g. ``windows-build``).
-* If instead you have compiled from source, navigate to the build directory (e.g. ``cd {path_to_repo}/target/release``
-  on MacOS).
-
-Here you are provided with two executables for running a server:
-
-* An executable for running via the command line (e.g. ``nanover-cli.exe`` on Windows)
-* An executable for running via the GUI (e.g. ``nanover-gui.exe`` on Windows)
-
-.. warning::
-    On MacOS, the first time you run either ``nanover-cli`` or ``nanover-gui`` from a downloaded release, it
-    is necessary to open the executables manually by
-
-    #. Opening the build directory in Finder
-    #. Right-clicking the executables and selecting ``Open``
-    #. When prompted, click ``Open``
-
-    The same needs to be done for the ``libOpenMM`` executables in the ``lib`` and ``lib/plugins`` directories.
-
-via the command line
-~~~~~~~~~~~~~~~~~~~~
-
-To run the server using the command line, run the executable as a command, passing it the path to
-your NanoVer simulation file, e.g.:
-
-.. code-block::
-
-    # Windows Powershell
-    .\nanover-cli.exe "my-openmm-sim.xml"
-
-    # MacOS/Linux
-    ./nanover-cli "my-openmm-sim.xml"
-
-    # if you are not in the same directory as this executable, you will need to give the entire file path
-    # e.g. for Windows Powershell
-    .\path\to\build\directory\nanover-cli.exe "my-openmm-sim.xml"
-
-The server can serve multiple simulations: just pass it multiple input files.
-
-.. code-block::
-
-    # load several simulations onto the server by passing multiple simulation files, e.g. Windows Powershell
-    .\nanover-cli.exe "my-openmm-sim-1.xml" "my-openmm-sim-2.xml"
-
-
-.. _command line help:
-
-For more information about the arguments provided with this command, type:
-
-.. code-block::
-
-    # Windows Powershell
-    .\nanover-cli.exe --help
-
-    # MacOS/Linux
-    ./nanover-cli --help
-
-
-.. _rust_server_via_the_gui:
-
-via the GUI
-~~~~~~~~~~~
-
-To run the server via the GUI, open the ``nanover-gui`` executable (or run it via the command line e.g.
-``./nanover-gui`` on MacOS) and you will see the following interface:
-
-.. image:: /_static/nanover-server-rs-gui.png
-    :align: center
-    :scale: 50%
-
-|
-
-Simply click ``Run demonstration input!`` to run a demo simulation. Alternatively, click ``+OpenMM`` and select your
-own NanoVer OpenMM XML file, then click ``Run!`` to start the server. You can also add NanoVer recordings by
-clicking ``+Recording`` and selecting your trajectory (.traj) and shared state (.state) files.
-
-Please click on the headings to open up menus to customise your server further: ``Verbosity``, ``Network``,
-``Simulation``, and ``Recording``.
-For further information about these options, use the :ref:`help function <command line help>` in the command line.
 
 |
 
@@ -311,60 +192,6 @@ in the file.
 
     Further instructions and information on how to record and replay using the NanoVer Python module can be found in
     this notebook `recording_and_replaying.ipynb <https://github.com/IRL2/nanover-server-py/blob/main/examples/basics/recording_and_replaying.ipynb>`_.
-
-|
-
-----
-
-Recording with Rust
-###################
-
-You can ask the `Rust server <https://github.com/IRL2/nanover-server-rs>`_ to record your session when you start the
-server.
-
-.. note::
-
-    The Rust Server takes a snapshot of the streams 30 times a second (although this may change with
-    issues `#200 <https://github.com/IRL2/nanover-server-rs/issues/200>`_ and
-    `#201 <https://github.com/IRL2/nanover-server-rs/issues/201>`_).
-
-via the terminal
-~~~~~~~~~~~~~~~~
-
-When using the ``nanover-cli`` command via the command line, use the ``--trajectory`` argument to specify the file that
-will store the recording of the frame stream, and the ``--state`` argument to specify the file that will store
-the recording of the shared state updates.
-
-.. code-block::
-
-    # For Windows Powershell
-    .\nanover-cli.exe "simulation.xml" --trajectory "path/to/recording.traj" --state "path/to/recording.state"
-
-----
-
-via the GUI
-~~~~~~~~~~~
-
-On the graphical user interface (GUI), the files are specified in the ``Recording`` section before starting the server
-(see :ref:`rust_server_via_the_gui`).
-
-----
-
-Visualising recordings
-~~~~~~~~~~~~~~~~~~~~~~
-
-**Using the the command line**, providing only a ``.traj`` file will stream the frames only,
-and providing only a ``.state`` file will stream the state updates only.
-In order to send both streams together, provide the two file paths separated by a colon:
-
-.. code-block::
-
-    # For Windows Powershell
-    .\nanover-cli.exe "path/to/recording.traj:path/to/recording.state"
-
-
-**Using the graphical interface**, add a recording to the list of simulations using the ``+ Recording`` button,
-then choose the files.
 
 |
 


### PR DESCRIPTION
This server is no longer maintained and is not compatible with current versions of the client.